### PR TITLE
fix(roles): roles page bugs

### DIFF
--- a/src/routes/Roles/components/RoleForm/index.jsx
+++ b/src/routes/Roles/components/RoleForm/index.jsx
@@ -89,6 +89,14 @@ function RoleForm() {
 
   const editRate = useCallback(
     (index, changes) => {
+      // a num field is `null` but user trying to increase/decrease it
+      // start with 0
+      for (const key in changes) {
+        if (isNaN(changes[key])) {
+          changes[key] = 0;
+        }
+      }
+      // apply changes
       dispatch(
         setModalRole({
           ...roleState,

--- a/src/routes/Roles/index.jsx
+++ b/src/routes/Roles/index.jsx
@@ -3,7 +3,12 @@ import { useDispatch, useSelector } from "react-redux";
 import debounce from "lodash/debounce";
 import omit from "lodash/omit";
 import withAuthentication from "hoc/withAuthentication";
-import { setFilter, setIsModalOpen, setModalRole } from "store/actions/roles";
+import {
+  setFilter,
+  setIsModalOpen,
+  setModalError,
+  setModalRole,
+} from "store/actions/roles";
 import { createRole, deleteRole, updateRole } from "store/thunks/roles";
 import {
   getRolesIsModalOpen,
@@ -48,6 +53,7 @@ const Roles = () => {
 
   const onCreateClick = useCallback(() => {
     setModalOperationType("CREATE");
+    dispatch(setModalError(null));
     // role template with initial values
     dispatch(
       setModalRole({
@@ -65,6 +71,7 @@ const Roles = () => {
   const onEditClick = useCallback(
     (role) => {
       setModalOperationType("EDIT");
+      dispatch(setModalError(null));
       dispatch(setModalRole(role));
       dispatch(setIsModalOpen(true));
     },
@@ -74,6 +81,7 @@ const Roles = () => {
   const onDeleteClick = useCallback(
     (role) => {
       setModalOperationType("DELETE");
+      dispatch(setModalError(null));
       dispatch(setModalRole(role));
       dispatch(setIsModalOpen(true));
     },

--- a/src/store/thunks/roles.js
+++ b/src/store/thunks/roles.js
@@ -39,7 +39,7 @@ export const createRole = (body) => async (dispatch) => {
     const role = extractResponseData(response);
     dispatch(actions.createRole(role));
     dispatch(actions.setIsModalOpen(false));
-    makeToast("Successfully craeted the role.", "success");
+    makeToast("Successfully created the role.", "success");
   } catch (error) {
     dispatch(
       actions.setModalError(`Failed to create the role.\n${error.toString()}`)


### PR DESCRIPTION
* (b11eb0d) fix(roles): reset modalError when re-opened
  * The `modalError` of the previous operation was still being displayed
    even after closing & opening the modal again.
  * This fix resets the `modalError` each time it re-opened.

    Addresses topcoder-platform/taas-app#423
* (6c79c7a) fix(roles): typo in the role creation notification
  * Fix a typo in the "Successfully craeted the role." message
  of role creation notification.
  * Replace `craeted` -> `created`

    Addresses topcoder-platform/taas-app#422
* (870b4d5) fix(roles): `NaN` rate values in the RoleForm
  * Fix a bug with the `IntegerField` controls of the `RoleForm`,
  that was occurring when user trying to increase/decrease
  a number field which initially has `null`.
  * This was causing `NaN` values in the field.
  * This fix starts `IntegerField` controls with `0`,
    in case the user is trying to increase/decrease a `null` field.

    Addresses topcoder-platform/taas-app#421